### PR TITLE
Change Homebrew package name

### DIFF
--- a/content/get-started/getting-started-with-git/caching-your-github-credentials-in-git.md
+++ b/content/get-started/getting-started-with-git/caching-your-github-credentials-in-git.md
@@ -49,7 +49,7 @@ For more information about authenticating with {% data variables.product.prodnam
 
    ```shell
    brew tap microsoft/git
-   brew install --cask git-credential-manager-core
+   brew install --cask git-credential-manager
    ```
 
   For MacOS, you don't need to run `git config` because GCM automatically configures Git for you.


### PR DESCRIPTION
Changed git-credential-manager-core to git-credential-manager

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Brew package name seems to be updated since this doc was made. The one mentioned earlier does not work.

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

git-credential-manager-core to git-credential-manager

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [✔️ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [✔️ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
